### PR TITLE
Change to lowercase import path for sirupsen/logrus

### DIFF
--- a/filename/filename.go
+++ b/filename/filename.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Hook struct {

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/getsentry/raven-go"
 )
 


### PR DESCRIPTION
Sirupsen has changed import paths to the lowercase form. These changes migrates the hooks to that new form of import path.

Without it, users will have trouble using the hooks with the latest version of logrus.