### PR TITLE
Flush issues on panic or fatal level

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ package main
 import (
   "net/http"
   
-  "github.com/onrik/logrus/filename"
-  "github.com/onrik/logrus/sentry"
+  "github.com/Decentr-net/logrus/filename"
+  "github.com/Decentr-net/logrus/sentry"
   log "github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module github.com/onrik/logrus
+module github.com/Decentr-net/logrus
+
+go 1.14

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -63,6 +63,10 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 	hub := sentry.CurrentHub()
 	hook.client.CaptureEvent(&event, nil, hub.Scope())
 
+	if entry.Level == logrus.PanicLevel || entry.Level == logrus.FatalLevel {
+		hook.Flush()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Now such code will send issue

```
hook, err := sentry.NewHook(sentry.Options{
	Dsn:              opts.SentryDSN,
	AttachStacktrace: true,
	Release:          health.GetVersion(),
}, logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel)

if err != nil {
	logrus.WithError(err).Fatal("failed to init sentry")
}

logrus.AddHook(hook)

logrus.WithError(errors.New("test")).Fatal("test")
```