### PR TITLE
Fix example: logrus.AddHook() args + add deferred flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hooks for [logrus](https://github.com/Sirupsen/logrus)
 
-Example
+## Example
+
 ```go
 package main
 
@@ -23,16 +24,16 @@ func main() {
 
     sentryHook, err := sentry.NewHook(sentry.Options{
         Dsn: dsn,
-    })
+    }, log.PanicLevel, log.FatalLevel, log.ErrorLevel)
     if err != nil {
         log.Error(err)
         return
     }
-    log.AddHook(sentryHook, log.PanicLevel, log.FatalLevel, log.ErrorLevel)
+    defer sentryHook.Flush()
+    
+    log.AddHook(sentryHook)
 
     err = fmt.Errorf("test error")
     log.WithError(err).Error("Dead beef")
 }
-
-
 ```


### PR DESCRIPTION
The levels have to be set earlier, otherwise the example can't run:

```
» go run main.go
# command-line-arguments
./main.go:27:13: too many arguments in call to logrus.AddHook
	have (*"github.com/onrik/logrus/sentry".Hook, logrus.Level, logrus.Level, logrus.Level)
	want (logrus.Hook)
```


Also, `sentry-go` flushes event asynchronously, so if we don't wait after the final `log.Error()`, the program will be terminated before the event is sent. I added a `defer sentryHook.Flush()` otherwise the example doesn't work.